### PR TITLE
Fix several dev guide links pointing to a deprecated repository

### DIFF
--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -10,4 +10,4 @@ A design and development guide for the Buttplug Intimate Device Control System.
 By [Kyle Machulis (qDot)](https://kyle.machul.is/about), Lead Buttplug Architect
 
 The Developers Guide Repo is [available on
-github](https://github.com/buttplugio/buttplug-developer-guide).
+github](https://github.com/buttplugio/docs.buttplug.io/tree/master/docs/dev-guide).

--- a/docs/dev-guide/writing-buttplug-applications/api-basics.mdx
+++ b/docs/dev-guide/writing-buttplug-applications/api-basics.mdx
@@ -121,7 +121,7 @@ import RustExample from '!!raw-loader!/examples/rust/src/bin/async.rs';
 </TabItem>
 <TabItem value="csharp" label="C#">
 
-[See it on Github](https://github.com/buttplugio/buttplug-developer-guide/tree/master/examples/csharp/AsyncExample)
+[See it on Github](https://github.com/buttplugio/docs.buttplug.io/tree/master/examples/csharp/AsyncExample)
 
 import CSharpExample from '!!raw-loader!/examples/csharp/AsyncExample/Program.cs';
 

--- a/docs/dev-guide/writing-buttplug-applications/intro.md
+++ b/docs/dev-guide/writing-buttplug-applications/intro.md
@@ -14,7 +14,7 @@ use some of the other features in the library.
 
 ## Example Code Access
 
-All of the example code in this section, as well as in the rest of the Developer Guide, is available in the [github repo for the Dev Guide](https://github.com/buttplugio/buttplug-developer-guide/tree/master/examples). This includes both the code itself and sometimes project files (VS Studio projects, Cargo.toml for rust, etc) for building the applications.
+All of the example code in this section, as well as in the rest of the Developer Guide, is available in the [github repo for the Dev Guide](https://github.com/buttplugio/docs.buttplug.io/tree/master/examples). This includes both the code itself and sometimes project files (VS Studio projects, Cargo.toml for rust, etc) for building the applications.
 
-We will do our best to keep these as up to date as possible, but if you run into any issues with compatibility or compilation, please [file an issue on the dev guide repo](https://github.com/buttplugio/buttplug-developer-guide/issues).
+We will do our best to keep these as up to date as possible, but if you run into any issues with compatibility or compilation, please [file an issue on the dev guide repo](https://github.com/buttplugio/docs.buttplug.io/issues).
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,15 +113,15 @@ const config = {
             items: [
               {
                 label: 'Buttplug Developer Guide',
-                to: 'https://buttplug-developer-guide.docs.buttplug.io',
+                to: 'https://docs.buttplug.io/docs/dev-guide/',
               },
               {
                 label: 'Buttplug Protocol Spec',
-                to: 'https://buttplug-spec.docs.buttplug.io',
+                to: 'https://docs.buttplug.io/docs/spec/',
               },
               {
                 label: 'Sex Toy Protocols I Have Known And Loved',
-                to: 'https://stpihkal.docs.buttplug.io',
+                to: 'https://docs.buttplug.io/docs/stpihkal/',
               },
             ],
           },


### PR DESCRIPTION
Several links pointing to the developer docs were pointing to the old, deprecated and archived repo for it, instead of the correct repo.