### PR TITLE
Add link to F-Machine RF Protocol Docs

### DIFF
--- a/stpihkal/protocols/f-machine/f-machine-rf.md
+++ b/stpihkal/protocols/f-machine/f-machine-rf.md
@@ -328,3 +328,4 @@ console.log("Done writing to data.bin!");
   - [Gigolo manual](https://f-machine.com/brochure/Gigolo_Brochure_Version2.pdf)
   - [Tremblr manual](https://f-machine.com/brochure/FINAL-TremblrBrochure.pdf)
 - [HackRF One official website](https://greatscottgadgets.com/hackrf/one/)
+- [BTR-Bridge - A $10 BLE to RF Bridge for the Tremblr & Gigolo](https://github.com/penaltybush/BTR-Bridge)


### PR DESCRIPTION
Feel free to close this if it's not suitable but I've finally got around to releasing the code for a BLE to RF bridge for the F-Machine Tremblr and Gigolo.

This is something I originally built from the BLE (#13) and RF docs on here back at the end of 2023 and only just got around to publishing.

I was hoping it might be possible to link to it from the Docs page in case anyone stumbles on the RF protocol docs wanting to automate the device.

I also completely understand if you don't want to be linking to another project as it could be considered endorsing that project.

I won't be offended if the answer is no.